### PR TITLE
Rejig site structure

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,9 +20,11 @@ defaults:
 collections:
   papers:
     output: true
-  conferences:
+  events:
     output: true
 
+gems:
+  - jekyll-redirect-from
 
 # Build settings
 markdown: kramdown

--- a/_events/velocityeu2014/2014-11-17.md
+++ b/_events/velocityeu2014/2014-11-17.md
@@ -3,6 +3,7 @@ layout: post
 title:  "Velocity EU Conference 2014 – Day 1"
 date:   2014-11-17 13:43:17
 tags: oreilly velocity conference 2014
+redirect_from: "/2014/11/17/velocityeu.html"
 ---
 TLDR; Velocity is a great conference for web and operations people, and why didn't you go already?
 

--- a/_events/velocityeu2014/2014-11-18.md
+++ b/_events/velocityeu2014/2014-11-18.md
@@ -3,6 +3,7 @@ layout: post
 title:  "Velocity EU Conference 2014 – Day 2"
 date:   2014-11-18 13:43:17
 tags: oreilly velocity conference 2014
+redirect_from: "/2014/11/18/velocityeu.html"
 ---
 Disclaimer -- 2 of my friends that I work with at the Government Digital Service (GDS) gave talks.
 

--- a/index.html
+++ b/index.html
@@ -1,29 +1,12 @@
 ---
 layout: default
 ---
-
-
-
 <div class="home">
 
-  <h1 class="page-heading">Posts</h1>
+  <h1 class="page-heading"><a href="/events/">Events</a></h1>
 
   <ul class="post-list">
-    {% for post in site.posts %}
-      <li>
-        <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
-
-        <h2>
-          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-        </h2>
-      </li>
-    {% endfor %}
-  </ul>
-
-  <h1 class="page-heading"><a href="/conferences/">Conferences</a></h1>
-
-  <ul class="post-list">
-    {% for post in site.conferences %}
+    {% for post in site.events %}
       <li>
         <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
 


### PR DESCRIPTION
Our model now has:
- events (which can include conferences and meet ups)
- papers (which should just be notes on academic papers)

Also added support for redirecting the old URLs since that’s the right
thing to do.
